### PR TITLE
fix origin mismatch if route differs from root due to proxy

### DIFF
--- a/drawio/js/editor.js
+++ b/drawio/js/editor.js
@@ -43,7 +43,7 @@
     OCA.DrawIO.EditFile = function (editWindow, filePath, origin) {
         var ncClient = OC.Files.getClient();
         var receiver = function (evt) {
-            if (evt.data.length > 0 && evt.origin === origin) {
+            if (evt.data.length > 0 && origin.includes(evt.origin)) {
                 var payload = JSON.parse(evt.data);
                 if (payload.event === "init") {
                     var loadMsg = OC.Notification.show(t(OCA.DrawIO.AppName, "Loading, please wait."));


### PR DESCRIPTION
 for example https://example.org/draw instead of https://example.org/