### PR TITLE
Allow NC13 + fix loading with defer loading of js scripts

### DIFF
--- a/drawio/appinfo/info.xml
+++ b/drawio/appinfo/info.xml
@@ -20,7 +20,7 @@
     <bugs>https://github.com/pawelrojek/nextcloud-drawio/issues</bugs>
     <repository type="git">https://github.com/pawelrojek/nextcloud-drawio.git</repository>
     <dependencies>
-        <nextcloud min-version="11" max-version="12"/>
+        <nextcloud min-version="11" max-version="13"/>
     </dependencies>
     <settings>
         <admin>OCA\Drawio\AdminSettings</admin>

--- a/drawio/templates/editor.php
+++ b/drawio/templates/editor.php
@@ -12,20 +12,19 @@
 
     <iframe id="iframeEditor" width="100%" height="100%" align="top" frameborder="0" name="iframeEditor" onmousewheel="" allowfullscreen=""></iframe>
 
-    <script type="text/javascript" nonce="<?php p(base64_encode($_["requesttoken"])) ?>">
-        $( document ).ready(function()
-        {
-        <?php if (!empty($_['error'])) { ?>
-            OCA.DrawIO.DisplayError("<?php p($_['error']) ?>");
-        <?php } else { ?>
-            var iframe = $("#iframeEditor")[0];
-            var filePath = "<?php p($_['filePath']); ?>";
-            var originUrl = "<?php p($_['drawioUrl']); ?>";
-            var drawIoUrl = "<?php p($_['drawioUrl']); print_unescaped($frame_params); ?>"
-            OCA.DrawIO.EditFile(iframe.contentWindow, filePath, originUrl);
-            iframe.setAttribute('src', drawIoUrl );
-        <?php } ?>
-        });
+    <script type="text/javascript" nonce="<?php p(base64_encode($_["requesttoken"])) ?>" defer>
+		window.addEventListener('DOMContentLoaded', function() {
+			<?php if (!empty($_['error'])) { ?>
+				OCA.DrawIO.DisplayError("<?php p($_['error']) ?>");
+			<?php } else { ?>
+				var iframe = $("#iframeEditor")[0];
+				var filePath = "<?php p($_['filePath']); ?>";
+				var originUrl = "<?php p($_['drawioUrl']); ?>";
+				var drawIoUrl = "<?php p($_['drawioUrl']); print_unescaped($frame_params); ?>"
+				OCA.DrawIO.EditFile(iframe.contentWindow, filePath, originUrl);
+				iframe.setAttribute('src', drawIoUrl );
+			<?php } ?>
+		});
     </script>
 
 </div>


### PR DESCRIPTION
Thanks for this awesome app, I use it frequently!

Nextcloud 13 is in beta, when I tested this app there was a little problem with loading the JS: `$` was undefined. This is probably caused by NC now using `defer` when loading JS files.