### PR TITLE
Add support to IE

### DIFF
--- a/drawio/js/editor.js
+++ b/drawio/js/editor.js
@@ -9,6 +9,20 @@
 
 (function (OCA) {
 
+    // ADD SUPPORT TO IE
+    if (!String.prototype.includes) {
+        String.prototype.includes = function(search, start) {
+            if (typeof start !== 'number') {
+                start = 0;
+            }
+            if (start + search.length > this.length) {
+                return false;
+            } else {
+                return this.indexOf(search, start) !== -1;
+            }
+        };
+    }
+
     OCA.DrawIO = _.extend({}, OCA.DrawIO);
     if (!OCA.DrawIO.AppName) {
         OCA.DrawIO = {


### PR DESCRIPTION
Creates the `<string>.includes()` function if it does not exist (Internet Explorer).
Solves https://github.com/pawelrojek/nextcloud-drawio/issues/22

Cheers!