### PR TITLE
allow querystring in custom drawioUrl

### DIFF
--- a/drawio/controller/editorcontroller.php
+++ b/drawio/controller/editorcontroller.php
@@ -103,6 +103,15 @@ class EditorController extends Controller
             return ["error" => $this->trans->t("Draw.io app not configured! Please contact admin.")];
         }
 
+        $drawioUrlArray = explode("?",$drawioUrl);
+
+        if (count($drawioUrlArray) > 1){
+            $drawioUrl = $drawioUrlArray[0];
+            $drawioUrlArgs = $drawioUrlArray[1];
+        } else {
+            $drawioUrlArgs = "";
+        }
+
         list ($file, $error) = $this->getFile($fileId);
 
         if (isset($error))
@@ -116,6 +125,7 @@ class EditorController extends Controller
 
         $params = [
             "drawioUrl" => $drawioUrl,
+            "drawioUrlArgs" => $drawioUrlArgs,
             "theme" => $theme,
             "lang" => $lang,
             "overrideXml" => $overrideXml,

--- a/drawio/templates/editor.php
+++ b/drawio/templates/editor.php
@@ -5,6 +5,7 @@
     $frame_params = "?embed=1";
     if (!empty($_["theme"])) $frame_params .= "&ui=".$_["theme"];
     if (!empty($_["lang"])) $frame_params .= "&lang=".$_["lang"];
+    if (!empty($_["drawioUrlArgs"])) $frame_params .= "&".$_["drawioUrlArgs"];
     $frame_params .= "&spin=1&proto=json";
 ?>
 


### PR DESCRIPTION
allow setting a querystring in drawioUrl.

possible parameters are listed here: https://desk.draw.io/support/solutions/articles/16000042546-what-url-parameters-are-supported-

take care that embed, ui, lang, spin, proto are added / controlled by the app, so they shall not be inculded in the custom url.

you can then have:
- mind maps (p=trees - ref. #36 )
- privacy (analytics=0 - disable google analitycs)
- avoid external dependencies (stealth=1 - ref. #2 )