### PR TITLE
fix Settings part is doubled #4

### DIFF
--- a/drawio/appinfo/info.xml
+++ b/drawio/appinfo/info.xml
@@ -23,6 +23,6 @@
         <nextcloud min-version="11" max-version="13"/>
     </dependencies>
     <settings>
-        <admin>OCA\Drawio\AdminSettings</admin>
+        <admin>OCA\Drawio\Settings\AdminSettings</admin>
     </settings>
 </info>


### PR DESCRIPTION
it should remove drawio settings from basic settings. they will be available only in additional settings

see #4 