### PR TITLE
Add custom file type ".drawio" in addition to ".xml"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,24 @@ App Store link: https://apps.nextcloud.com/apps/drawio
 - Multi language support (l10n)
 - Inspired by the old Draw.io Integration and OnlyOffice
 
+## Mimetype detection ##
+
+Unfortunately, apps can't declare new mimetypes on the fly. To make
+Draw.io work properly, you need to add a new mimetypes in the
+`mimetypemapping.json` file (at Nextcloud level).
+
+To proceed, just copy `/resources/config/mimetypemapping.dist.json` to
+`/config/mimetypemapping.json` (in the `config/` folder at Nextcloud’s
+root directory; the file should be stored next to the `config.php`
+file). Afterwards add the two following line just after the “_comment”
+lines.
+
+    "drawio": ["application/x-drawio"],
+
+If all other mimetypes are not working properly, just run the
+following command:
+
+    sudo -u www-data php occ files:scan --all
 
 ## Download ##
 [zip](https://github.com/pawelrojek/nextcloud-drawio/releases/download/v0.8.9/drawio-v0.8.9.zip) or [tar.gz](https://github.com/pawelrojek/nextcloud-drawio/releases/download/v0.8.9/drawio-v0.8.9.tar.gz)

--- a/drawio/js/main.js
+++ b/drawio/js/main.js
@@ -66,6 +66,8 @@
 
                     if ((fileList.fileActions.getDefaultFileAction(attr.mime, "file", OC.PERMISSION_READ) == false) || (OCA.AppSettings.overrideXml == "yes")) {
                         fileList.fileActions.setDefault(attr.mime, "drawioOpen");
+                    } else if(attr.mime == "application/x-drawio") {
+                        fileList.fileActions.setDefault(attr.mime, "drawioOpen");
                     }
                 });
             })
@@ -83,20 +85,37 @@
                 return;
             }
 
-            menu.addMenuEntry({
-                id: "drawIoDiagram",
-                displayName: t(OCA.DrawIO.AppName, "Diagram"),
-                              templateName: t(OCA.DrawIO.AppName, "New Diagram.xml"),
-                              iconClass: "icon-drawio-new-xml", //fileType: "x-application/drawio",
-                              fileType: "xml",
-                              actionHandler: function (fileName) {
-                                  var dir = fileList.getCurrentDirectory();
-                                  fileList.createFile(fileName)
-                                  .then(function () {
-                                      OCA.DrawIO.EditFileNewWindow(OC.joinPaths(dir, fileName));
-                                  });
-                              }
-            });
+            if(OCA.AppSettings.overrideXml == "yes") {
+                menu.addMenuEntry({
+                    id: "drawIoDiagram",
+                    displayName: t(OCA.DrawIO.AppName, "Diagram"),
+                                  templateName: t(OCA.DrawIO.AppName, "New Diagram.xml"),
+                                  iconClass: "icon-drawio-new-xml", //fileType: "x-application/drawio",
+                                  fileType: "xml",
+                                  actionHandler: function (fileName) {
+                                      var dir = fileList.getCurrentDirectory();
+                                      fileList.createFile(fileName)
+                                      .then(function () {
+                                          OCA.DrawIO.EditFileNewWindow(OC.joinPaths(dir, fileName));
+                                      });
+                                  }
+                });
+            } else {
+                menu.addMenuEntry({
+                    id: "drawIoDiagram",
+                    displayName: t(OCA.DrawIO.AppName, "Diagram"),
+                                  templateName: t(OCA.DrawIO.AppName, "New Diagram.drawio"),
+                                  iconClass: "icon-drawio-new-xml", //fileType: "x-application/drawio",
+                                  fileType: "drawio",
+                                  actionHandler: function (fileName) {
+                                      var dir = fileList.getCurrentDirectory();
+                                      fileList.createFile(fileName)
+                                      .then(function () {
+                                          OCA.DrawIO.EditFileNewWindow(OC.joinPaths(dir, fileName));
+                                      });
+                                  }
+                });
+            }
         }
     };
 })(OCA);
@@ -114,8 +133,29 @@ $(document)
         $("#filestable")
         .find("tr[data-type=file]")
         .each(function () {
+            if ((($(this)
+                .attr("data-mime") == "application/xml") ||
+                ($(this)
+                .attr("data-mime") == "application/x-drawio")) && ($(this)
+                .find("div.thumbnail")
+                .length > 0)) {
+                if ($(this)
+                    .find("div.thumbnail")
+                    .hasClass("icon-drawio-xml") == false) {
+                    $(this)
+                    .find("div.thumbnail")
+                    .addClass("icon icon-drawio-xml");
+                    }
+                }
+        });
+    };
+
+    PluginDrawIO_ChangeIconsNative = function () {
+        $("#filestable")
+        .find("tr[data-type=file]")
+        .each(function () {
             if (($(this)
-                .attr("data-mime") == "application/xml") && ($(this)
+                .attr("data-mime") == "application/x-drawio") && ($(this)
                 .find("div.thumbnail")
                 .length > 0)) {
                 if ($(this)
@@ -131,19 +171,23 @@ $(document)
 
     if ($('#filesApp')
         .val()) {
-
         $('#app-content-files')
         .add('#app-content-extstoragemounts')
         .on('changeDirectory', function (e) {
             if (OCA.AppSettings == null) return;
             if (OCA.AppSettings.overrideXml == "yes") {
                 PluginDrawIO_ChangeIcons();
+            } else {
+                PluginDrawIO_ChangeIconsNative();
             }
         })
         .on('fileActionsReady', function (e) {
+            PluginDrawIO_ChangeIconsNative();
             if (OCA.AppSettings == null) return;
             if (OCA.AppSettings.overrideXml == "yes") {
                 PluginDrawIO_ChangeIcons();
+            } else {
+                PluginDrawIO_ChangeIconsNative();
             }
         });
         }

--- a/drawio/js/main.js
+++ b/drawio/js/main.js
@@ -182,7 +182,6 @@ $(document)
             }
         })
         .on('fileActionsReady', function (e) {
-            PluginDrawIO_ChangeIconsNative();
             if (OCA.AppSettings == null) return;
             if (OCA.AppSettings.overrideXml == "yes") {
                 PluginDrawIO_ChangeIcons();

--- a/drawio/lib/appconfig.php
+++ b/drawio/lib/appconfig.php
@@ -119,7 +119,8 @@ class AppConfig {
      * @var array
      */
     public $formats = [
-            "xml" => [ "mime" => "application/xml", "type" => "text" ]
+            "xml" => [ "mime" => "application/xml", "type" => "text" ],
+            "drawio" => [ "mime" => "application/x-drawio", "type" => "text" ]
         ];
 
 }

--- a/drawio/templates/settings.php
+++ b/drawio/templates/settings.php
@@ -26,7 +26,7 @@
     <select id="overrideXml">
       <option value="yes"<?php if ($_["overrideXml"]=="yes") echo ' selected'; ?>><?php p($l->t("Yes")) ?></option>
       <option value="no"<?php if ($_["overrideXml"]=="no") echo ' selected'; ?>><?php p($l->t("No")) ?></option>
-    </select><br />
+    </select>
     </p>
 
 	<p><?php p($l->t("Please note: when you disable the XML association, you need to manually register the MIME type application/x-drawio for the extension \".drawio\".")) ?></p>

--- a/drawio/templates/settings.php
+++ b/drawio/templates/settings.php
@@ -26,8 +26,10 @@
     <select id="overrideXml">
       <option value="yes"<?php if ($_["overrideXml"]=="yes") echo ' selected'; ?>><?php p($l->t("Yes")) ?></option>
       <option value="no"<?php if ($_["overrideXml"]=="no") echo ' selected'; ?>><?php p($l->t("No")) ?></option>
-    </select>
+    </select><br />
     </p>
+
+	<p><?php p($l->t("Please note: when you disable the XML association, you need to manually register the MIME type application/x-drawio for the extension \".drawio\".")) ?></p>
 
     <br />
     <a id="drawioSave" class="button"><?php p($l->t("Save")) ?></a>


### PR DESCRIPTION
This is one possible way to deal with https://github.com/pawelrojek/nextcloud-drawio/issues/32.

My change adds the additional neccessary handling:

- additional MIME type `application/x-drawio` (extension `.drawio`) in the app configuration
- extending actions for opening files - `.drawio` will be handled as well and not only `.xml`
- if XML is not associated with Draw.io, the "new" action will create files with the extension `.drawio` and not `.xml`
- additional note in the admin settings about the need to register the MIME type manually

## To do

Translations for the admin settings note. And maybe we also find a more elegant way to deal with custom file types and the associated icons without "hacking" the file list on the fly.

## How to deal with the custom MIME type

Unfortunately an app can not extend the MIME type mapping in Nextcloud by itself (at least I don't know any official way) - however one can register this type manually (as described for Ownpad which also uses a custom file type):

Just copy `/resources/config/mimetypemapping.dist.json` to `/config/mimetypemapping.json` (in the `config/` folder at Nextcloud’s root directory; the file should be stored next to the `config.php` file). Afterwards add the two following line just after the “_comment” lines.

    "drawio": ["application/x-drawio"],

If all other mimetypes are not working properly, just run the following command:

    sudo -u www-data php occ files:scan --all
