### PR TITLE
Move settings into "additional" section

### DIFF
--- a/drawio/lib/adminsettings.php
+++ b/drawio/lib/adminsettings.php
@@ -32,7 +32,7 @@ class AdminSettings implements ISettings {
 
     public function getSection()
     {
-        return "server";
+        return "additional";
     }
 
     public function getPriority()


### PR DESCRIPTION
Settings for editor apps should probably be in the "additional" section (like OnlyOffice) or have their own sub-section (like Talk). This completes #4 .