### PR TITLE
Fix for OC10 admin menu

### DIFF
--- a/drawio/appinfo/app.php
+++ b/drawio/appinfo/app.php
@@ -13,4 +13,6 @@ namespace OCA\Drawio\AppInfo;
 
 use OCP\App;
 
+App::registerAdmin("drawio", "settings");
+
 $app = new Application();

--- a/drawio/appinfo/info.xml
+++ b/drawio/appinfo/info.xml
@@ -24,6 +24,6 @@
         <owncloud min-version="10.0" max-version="10.1" />
     </dependencies>
     <settings>
-        <admin>OCA\Drawio\AdminSettings</admin>
+	<admin>OCA\Drawio\Settings\AdminSettings</admin>
     </settings>
 </info>


### PR DESCRIPTION
Fix to get the ownCloud admin menu working. See also; https://github.com/pawelrojek/nextcloud-drawio/issues/72