### PR TITLE
remove 'organization' category

### DIFF
--- a/drawio/appinfo/info.xml
+++ b/drawio/appinfo/info.xml
@@ -13,7 +13,6 @@
     </types>
     <category>files</category>
     <category>integration</category>
-    <category>organization</category>
     <category>tools</category>
     <website>https://github.com/pawelrojek/nextcloud-drawio/</website>
     <screenshot small-thumbnail="https://raw.githubusercontent.com/pawelrojek/nextcloud-drawio/master/screenshots/drawio_integration_sm.png">https://raw.githubusercontent.com/pawelrojek/nextcloud-drawio/master/screenshots/drawio_integration.png</screenshot>


### PR DESCRIPTION
While, I suppose, drawings can be used to organize things I just don't think it fits with the tasks, calendar or polls apps.

And yes, a few others have to be removed there, too, I'm making a few PR's :D