### PR TITLE
Switchable autosave

### DIFF
--- a/drawio/controller/editorcontroller.php
+++ b/drawio/controller/editorcontroller.php
@@ -132,7 +132,8 @@ class EditorController extends Controller
             "drawioLang" => $lang,
             "drawioOverrideXml" => $overrideXml,
 			"drawioOfflineMode" => $offlineMode,
-            "drawioFilePath" => $baseFolder->getRelativePath($file->getPath())
+            "drawioFilePath" => $baseFolder->getRelativePath($file->getPath()),
+            "drawioAutosave" =>$this->config->GetAutosave()
         ];
 
         $response = new TemplateResponse($this->appName, "editor", $params);

--- a/drawio/controller/settingscontroller.php
+++ b/drawio/controller/settingscontroller.php
@@ -63,7 +63,8 @@ class SettingsController extends Controller
             "drawioOverrideXml" => $this->config->GetOverrideXml(),
             "drawioOfflineMode" => $this->config->GetOfflineMode(),
             "drawioTheme" => $this->config->GetTheme(),
-            "drawioLang" => $this->config->GetLang()
+            "drawioLang" => $this->config->GetLang(),
+            "drawioAutosave" => $this->config->GetAutosave()
         ];
         return new TemplateResponse($this->appName, "settings", $data, "blank");
     }
@@ -77,19 +78,22 @@ class SettingsController extends Controller
         $offlinemode = trim($_POST['offlineMode']);
         $theme = trim($_POST['theme']);
         $lang = trim($_POST['lang']);
+        $autosave = trim($_POST['autosave']);
 
         $this->config->SetDrawioUrl($drawio);
         $this->config->SetOverrideXml($overridexml);
         $this->config->SetOfflineMode($offlinemode);
         $this->config->SetTheme($theme);
         $this->config->SetLang($lang);
+        $this->config->SetAutosave($autosave);
 
         return [
             "drawioUrl" => $this->config->GetDrawioUrl(),
             "overrideXml" => $this->config->GetOverrideXml(),
             "offlineMode" => $this->config->GetOfflineMode(),
             "theme" => $this->config->GetTheme(),
-            "lang" => $this->config->GetLang()
+            "lang" => $this->config->GetLang(),
+            "drawioAutosave" =>$this->config->GetAutosave()
             ];
     }
 

--- a/drawio/js/settings.js
+++ b/drawio/js/settings.js
@@ -25,6 +25,7 @@
             var f_offlineMode = $("#offlineMode option:selected").val();
             var f_theme = $("#theme option:selected").val();
             var f_lang = $("#lang").val().trim();
+            var f_autosave = $("#drawioAutosave option:selected").val();
 
             var saving = OC.Notification.show( t(OCA.Drawio.AppName, "Saving...") );
 
@@ -33,7 +34,8 @@
                     overrideXml: f_overrideXml,
                     offlineMode: f_offlineMode,
                     theme: f_theme,
-                    lang: f_lang
+                    lang: f_lang,
+                    autosave: f_autosave
             };
 
 
@@ -52,6 +54,7 @@
                         $("#offlineMode").val(response.offlineMode);
                         $("#theme").val(response.theme);
                         $("#lang").val(response.lang);
+                        $("#drawioAutosave").val(response.drawioAutosave);
 
                         var message =
                             response.error

--- a/drawio/l10n/ru.js
+++ b/drawio/l10n/ru.js
@@ -31,6 +31,7 @@ OC.L10N.register(
   "The file has changed since opening" : "Файл был изменен с момента открытия",
   "User does not have permissions to write to the file:" : "У пользователя недостаточно прав для записи в данный файл:",
   "FileId is empty" : "FileId пуст",
-  "You do not have enough permissions to view the file" : "У Вас недостаточно прав на просмотр данного файла"
+  "You do not have enough permissions to view the file" : "У Вас недостаточно прав на просмотр данного файла",
+  "Activate autosave?" : "Включить автосохранение?"
 },
 "nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);");

--- a/drawio/l10n/ru.json
+++ b/drawio/l10n/ru.json
@@ -29,6 +29,7 @@
   "The file has changed since opening" : "Файл был изменен с момента открытия",
   "User does not have permissions to write to the file:" : "У пользователя недостаточно прав для записи в данный файл:",
   "FileId is empty" : "FileId пуст",
-  "You do not have enough permissions to view the file" : "У Вас недостаточно прав на просмотр данного файла"
+  "You do not have enough permissions to view the file" : "У Вас недостаточно прав на просмотр данного файла",
+  "Activate autosave?" : "Включить автосохранение?"
 },"pluralForm" :"nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);"
 }

--- a/drawio/l10n/ru.php
+++ b/drawio/l10n/ru.php
@@ -30,6 +30,7 @@ $TRANSLATIONS = array(
   "The file has changed since opening" => "Файл был изменен с момента открытия",
   "User does not have permissions to write to the file:" => "У пользователя недостаточно прав для записи в данный файл:",
   "FileId is empty" => "FileId пуст",
-  "You do not have enough permissions to view the file" => "У Вас недостаточно прав на просмотр данного файла"
+  "You do not have enough permissions to view the file" => "У Вас недостаточно прав на просмотр данного файла",
+  "Activate autosave?" => "Включить автосохранение?"
 );
 $PLURAL_FORMS = "nplurals=3; plural=(n==1 ? 0 => n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 => 2);";

--- a/drawio/lib/appconfig.php
+++ b/drawio/lib/appconfig.php
@@ -22,6 +22,7 @@ class AppConfig {
     private $predefOfflineMode = "no";
     private $predefTheme = "kennedy"; //kennedy, minimal, atlas, dark
     private $predefLang = "auto";
+    private $predefAutosave = "yes";
 
     private $appName;
 
@@ -35,6 +36,7 @@ class AppConfig {
     private $_offlinemode = "DrawioOffline";
     private $_theme = "DrawioTheme";
     private $_lang = "DrawioLang";
+    private $_autosave = "DrawioAutosave";
 
     public function __construct($AppName)
     {
@@ -110,6 +112,19 @@ class AppConfig {
     {
         $val = $this->config->getAppValue($this->appName, $this->_lang);
         if (empty($val)) $val = $this->predefLang;
+        return $val;
+    }
+
+    public function SetAutosave($autosave)
+    {
+        $this->logger->info("SetAutosave: " . $autosave, array("app" => $this->appName));
+        $this->config->setAppValue($this->appName, $this->_autosave, $autosave);
+    }
+
+    public function GetAutosave()
+    {
+        $val = $this->config->getAppValue($this->appName, $this->_autosave);
+        if (empty($val)) $val = $this->predefAutosave;
         return $val;
     }
 

--- a/drawio/templates/editor.php
+++ b/drawio/templates/editor.php
@@ -26,8 +26,10 @@
                 var filePath = "<?php echo urldecode($_['drawioFilePath']); ?>";
                 var originUrl = "<?php p($_['drawioUrl']); ?>";
                 var drawIoUrl = "<?php p($_['drawioUrl']); print_unescaped($frame_params); ?>"
-                OCA.DrawIO.EditFile(iframe.contentWindow, filePath, originUrl);
-                iframe.setAttribute('src', drawIoUrl );
+                var autosave = "<?php p($_['drawioAutosave']); ?>";
+
+                OCA.DrawIO.EditFile(iframe.contentWindow, filePath, originUrl, autosave);
+                iframe.setAttribute('src', drawIoUrl);
             <?php } ?>
         });
     </script>

--- a/drawio/templates/settings.php
+++ b/drawio/templates/settings.php
@@ -43,6 +43,14 @@
 
     <p><?php p($l->t("When the \"offline mode\" is active, this disables all remote operations and features to protect the users privacy. Draw.io will then also only be in English, even if you set a different language manually.")) ?></p>
 
+    <p class="drawio-header">
+        <label for='drawioAutosave'><?php p($l->t("Activate autosave?")) ?>
+            <select id="drawioAutosave">
+                <option value="yes"<?php if ($_["drawioAutosave"]=="yes") echo ' selected'; ?>><?php p($l->t("Yes")) ?></option>
+                <option value="no"<?php if ($_["drawioAutosave"]=="no") echo ' selected'; ?>><?php p($l->t("No")) ?></option>
+            </select>
+    </p>
+
     <br />
     <a id="drawioSave" class="button"><?php p($l->t("Save")) ?></a>
 </div>


### PR DESCRIPTION
**I added:**
1) Autosave
2) Settings to enable/disable autosave
3) Browser no longer writes about unsaved changes

**Disadvantages:**
1) "Save" button is useless
2) It requires something special to translate the status
3) User cannot undo all the changed (but 
4) I cannot use autosaveDelay. Even if it set, it doesn't influence in my case (I have the same number of autosave events came from server whether I set it or not)

**Uncommitted, but done:**
I reassigned "Save" to create a checkpoint and "Exit" to revert to it and exit. When I load file, I create checkpoint too. I store it in localStorage. It was requirement from my users, but result is controversial -- I need to rename buttons to make sence.