### PR TITLE
Enhance README.md with info about draw.io self-hosting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Go to Admin page and change the settings you want:
 
 Click "Save" when you're done.
 
+If you would like to self-host Draw.io, you might want to consider https://github.com/jgraph/docker-drawio from the creators of Draw.io (now [diagrams.net](https://www.diagrams.net/)).
+
 
 ## License ##
 - Released under the Affero General Public License version 3 or later.


### PR DESCRIPTION
Maybe an update of the screenshot drawio_admin.png is useful, too (as www.draw.io is nowadays automatically forwarded to https://app.diagrams.net/)