### PR TITLE
Some translations

### DIFF
--- a/drawio/l10n/de.js
+++ b/drawio/l10n/de.js
@@ -9,6 +9,7 @@ OC.L10N.register(
   "Loading, please wait." : "Laden, bitte warten.",
   "File created" : "Datei erstellt",
   "Diagram" : "Diagramm",
+  "New Diagram" : "Neues Diagramm",
   "Yes" : "Ja",
   "No" : "Nein",
   "Associate XML files with Draw.io?" : "XML Dateien mit Draw.io öffnen?",

--- a/drawio/l10n/de.json
+++ b/drawio/l10n/de.json
@@ -7,6 +7,7 @@
   "Loading, please wait." : "Laden, bitte warten.",
   "File created" : "Datei erstellt",
   "Diagram" : "Diagramm",
+  "New Diagram" : "Neues Diagramm",
   "Yes" : "Ja",
   "No" : "Nein",
   "Associate XML files with Draw.io?" : "XML Dateien mit Draw.io öffnen?",

--- a/drawio/l10n/de.php
+++ b/drawio/l10n/de.php
@@ -8,6 +8,7 @@ $TRANSLATIONS = array(
   "Loading, please wait." => "Laden, bitte warten.",
   "File created" => "Datei erstellt",
   "Diagram" => "Diagramm",
+  "New Diagram" => "Neues Diagramm",
   "Yes" => "Ja",
   "No" => "Nein",
   "Associate XML files with Draw.io?" => "XML Dateien mit Draw.io öffnen?",

--- a/drawio/l10n/de_DE.js
+++ b/drawio/l10n/de_DE.js
@@ -9,6 +9,7 @@ OC.L10N.register(
   "Loading, please wait." : "Laden, bitte warten.",
   "File created" : "Datei erstellt",
   "Diagram" : "Diagramm",
+  "New Diagram" : "Neues Diagramm",
   "Yes" : "Ja",
   "No" : "Nein",
   "Associate XML files with Draw.io?" : "XML Dateien mit Draw.io öffnen?",

--- a/drawio/l10n/de_DE.json
+++ b/drawio/l10n/de_DE.json
@@ -7,6 +7,7 @@
   "Loading, please wait." : "Laden, bitte warten.",
   "File created" : "Datei erstellt",
   "Diagram" : "Diagramm",
+  "New Diagram" : "Neues Diagramm",
   "Yes" : "Ja",
   "No" : "Nein",
   "Associate XML files with Draw.io?" : "XML Dateien mit Draw.io öffnen?",

--- a/drawio/l10n/de_DE.php
+++ b/drawio/l10n/de_DE.php
@@ -8,6 +8,7 @@ $TRANSLATIONS = array(
   "Loading, please wait." => "Laden, bitte warten.",
   "File created" => "Datei erstellt",
   "Diagram" => "Diagramm",
+  "New Diagram" => "Neues Diagramm",
   "Yes" => "Ja",
   "No" => "Nein",
   "Associate XML files with Draw.io?" => "XML Dateien mit Draw.io öffnen?",

--- a/drawio/l10n/pl.js
+++ b/drawio/l10n/pl.js
@@ -9,6 +9,7 @@ OC.L10N.register(
   "Loading, please wait." : "Wczytuję, proszę czekać.",
   "File created" : "Plik został utworzony",
   "Diagram" : "Schemat",
+  "New Diagram" : "Nowy schemat",
   "Yes" : "Tak",
   "No" : "Nie",
   "Associate XML files with Draw.io?" : "Przejąć obsługę formatu XML?",

--- a/drawio/l10n/pl.json
+++ b/drawio/l10n/pl.json
@@ -7,6 +7,7 @@
   "Loading, please wait." : "Wczytuję, proszę czekać.",
   "File created" : "Plik został utworzony",
   "Diagram" : "Schemat",
+  "New Diagram" : "Nowy schemat",
   "Yes" : "Tak",
   "No" : "Nie",
   "Associate XML files with Draw.io?" : "Przejąć obsługę formatu XML?",

--- a/drawio/l10n/pl.php
+++ b/drawio/l10n/pl.php
@@ -8,6 +8,7 @@ $TRANSLATIONS = array(
   "Loading, please wait." => "Wczytuję, proszę czekać.",
   "File created" => "Plik został utworzony",
   "Diagram" => "Schemat",
+  "New Diagram" => "Nowy schemat",
   "Yes" => "Tak",
   "No" => "Nie",
   "Associate XML files with Draw.io?" => "Przejąć obsługę formatu XML?",

--- a/drawio/l10n/pt_BR.js
+++ b/drawio/l10n/pt_BR.js
@@ -9,6 +9,7 @@ OC.L10N.register(
   "Loading, please wait." : "Carregando, por favor aguarde.",
   "File created" : "Arquivo criado",
   "Diagram" : "Diagrama",
+  "New Diagram" : "Novo diagrama",
   "Yes" : "Sim",
   "No" : "Não",
   "Associate XML files with Draw.io?" : "Associar arquivos XML com o Draw.io?",

--- a/drawio/l10n/pt_BR.json
+++ b/drawio/l10n/pt_BR.json
@@ -7,6 +7,7 @@
   "Loading, please wait." : "Carregando, por favor aguarde.",
   "File created" : "Arquivo criado",
   "Diagram" : "Diagrama",
+  "New Diagram" : "Novo diagrama",
   "Yes" : "Sim",
   "No" : "Não",
   "Associate XML files with Draw.io?" : "Associar arquivos XML com o Draw.io?",

--- a/drawio/l10n/pt_BR.php
+++ b/drawio/l10n/pt_BR.php
@@ -8,6 +8,7 @@ $TRANSLATIONS = array(
   "Loading, please wait." => "Carregando, por favor aguarde.",
   "File created" => "Arquivo criado",
   "Diagram" => "Diagrama",
+  "New Diagram" => "Novo diagrama",
   "Yes" => "Sim",
   "No" => "Não",
   "Associate XML files with Draw.io?" => "Associar arquivos XML com o Draw.io?",

--- a/drawio/l10n/ru.js
+++ b/drawio/l10n/ru.js
@@ -9,6 +9,7 @@ OC.L10N.register(
   "Loading, please wait." : "Загрузка. Пожалуйста, подождите.",
   "File created" : "Файл создан",
   "Diagram" : "Диаграмма",
+  "New Diagram" : "Новая диаграмма",
   "Yes" : "Да",
   "No" : "Нет",
   "Associate XML files with Draw.io?" : "Ассоциировать XML-формат с Draw.io?",

--- a/drawio/l10n/ru.json
+++ b/drawio/l10n/ru.json
@@ -7,6 +7,7 @@
   "Loading, please wait." : "Загрузка. Пожалуйста, подождите.",
   "File created" : "Файл создан",
   "Diagram" : "Диаграмма",
+  "New Diagram" : "Новая диаграмма",
   "Yes" : "Да",
   "No" : "Нет",
   "Associate XML files with Draw.io?" : "Ассоциировать XML-формат с Draw.io?",

--- a/drawio/l10n/ru.php
+++ b/drawio/l10n/ru.php
@@ -8,6 +8,7 @@ $TRANSLATIONS = array(
   "Loading, please wait." => "Загрузка. Пожалуйста, подождите.",
   "File created" => "Файл создан",
   "Diagram" => "Диаграмма",
+  "New Diagram" => "Новая диаграмма",
   "Yes" => "Да",
   "No" => "Нет",
   "Associate XML files with Draw.io?" => "Ассоциировать XML-формат с Draw.io?",


### PR DESCRIPTION
Hello,
Once in Files menu you changed "Diagram" to "New Diagram", and for all the languages it's not translated.
I tried to fix it.
1)  Based on @trendchiller's issue #102 I took "Neues Diagramm" as a translation for both versions of German. Let him review.
2) For pt_BR I took "New Diagram.xml" : "Novo Diagrama.xml" and deleted xml. 
3) For Polish as far as I know it, it should be "Nowy schemat".
4) I'm sure in Russian.

Somewhere based on other menu items I changed letter in 'Diagram' to lowercase. 