### PR TITLE
Fix content detection

### DIFF
--- a/drawio/js/editor.js
+++ b/drawio/js/editor.js
@@ -68,7 +68,7 @@
                                 action: "template",
                                 name: filePath
                             }), "*");
-                        } else if (contents.indexOf("mxGraphModel") !== -1) {
+                        } else if (contents.indexOf("mxfile") == -1 || contents.indexOf("diagram") == -1) {
                             // TODO: show error to user
                             OCA.DrawIO.Cleanup(receiver, filePath);
                         } else {


### PR DESCRIPTION
This fix changes the file content detection to support compressed and uncompressed draw.io files, effectively fixing the editor redirect issue in pawelrojek#92

Without this fix files that are uncompressed - like those created by the VS Code draw.io extension - would not open from NC. The editor would open for a split second and then redirect back to the file list.