### PR TITLE
fix for #78 added option to enable libraries

### DIFF
--- a/drawio/controller/editorcontroller.php
+++ b/drawio/controller/editorcontroller.php
@@ -221,6 +221,7 @@ class EditorController extends Controller
       	    "drawioOfflineMode" => $offlineMode,
             "drawioFilePath" => rawurlencode($relativePath),
             "drawioAutosave" =>$this->config->GetAutosave(),
+            "drawioLibraries" =>$this->config->GetLibraries(),
             "fileId" => $fileId,
             "filePath" => $filePath,
             "shareToken" => $shareToken

--- a/drawio/controller/settingscontroller.php
+++ b/drawio/controller/settingscontroller.php
@@ -65,6 +65,7 @@ class SettingsController extends Controller
             "drawioTheme" => $this->config->GetTheme(),
             "drawioLang" => $this->config->GetLang(),
             "drawioAutosave" => $this->config->GetAutosave()
+            "drawioLibraries" => $this->config->GetLibraries()
         ];
         return new TemplateResponse($this->appName, "settings", $data, "blank");
     }
@@ -78,12 +79,14 @@ class SettingsController extends Controller
         $theme = trim($_POST['theme']);
         $lang = trim($_POST['lang']);
         $autosave = trim($_POST['autosave']);
+        $libraries = trim($_POST['libraries']);
 
         $this->config->SetDrawioUrl($drawio);
         $this->config->SetOfflineMode($offlinemode);
         $this->config->SetTheme($theme);
         $this->config->SetLang($lang);
         $this->config->SetAutosave($autosave);
+        $this->config->SetLibraries($libraries);
 
         if (version_compare(implode(".", \OCP\Util::getVersion()), "13", ">=")) {
             $checkmime = new \OCA\Drawio\Migration\CheckMimeType();
@@ -103,6 +106,7 @@ class SettingsController extends Controller
             "theme" => $this->config->GetTheme(),
             "lang" => $this->config->GetLang(),
             "drawioAutosave" =>$this->config->GetAutosave()
+            "drawioLibraries" =>$this->config->GetLibraries()
             ];
     }
 

--- a/drawio/controller/viewercontroller.php
+++ b/drawio/controller/viewercontroller.php
@@ -183,6 +183,7 @@ class ViewerController extends Controller
       	    "drawioOfflineMode" => $offlineMode,
             //"drawioFilePath" => rawurlencode($relativePath), // info not needed for public view
             "drawioAutosave" => $this->config->GetAutosave(),
+            "drawioLibraries" =>$this->config->GetLibraries(),
             "fileId" => $fileId,
             "filePath" => $filePath,
             "shareToken" => $shareToken,

--- a/drawio/js/settings.js
+++ b/drawio/js/settings.js
@@ -25,6 +25,7 @@
             var f_theme = $("#theme option:selected").val();
             var f_lang = $("#lang").val().trim();
             var f_autosave = $("#drawioAutosave option:selected").val();
+            var f_libraries = $("#drawioLibraries option:selected").val();
 
             var saving = OC.Notification.show( t(OCA.Drawio.AppName, "Saving...") );
 
@@ -33,7 +34,8 @@
                     offlineMode: f_offlineMode,
                     theme: f_theme,
                     lang: f_lang,
-                    autosave: f_autosave
+                    autosave: f_autosave,
+                    libraries: f_libraries
             };
 
 
@@ -52,6 +54,7 @@
                         $("#theme").val(response.theme);
                         $("#lang").val(response.lang);
                         $("#drawioAutosave").val(response.drawioAutosave);
+                        $("#drawioLibraries").val(response.libraries);
 
                         var message =
                             response.error

--- a/drawio/lib/appconfig.php
+++ b/drawio/lib/appconfig.php
@@ -22,6 +22,7 @@ class AppConfig {
     private $predefTheme = "kennedy"; //kennedy, minimal, atlas, dark
     private $predefLang = "auto";
     private $predefAutosave = "yes";
+    private $predefLibraries = "no";
 
     private $appName;
 
@@ -35,6 +36,7 @@ class AppConfig {
     private $_theme = "DrawioTheme";
     private $_lang = "DrawioLang";
     private $_autosave = "DrawioAutosave";
+    private $_libraries = "DrawioLibraries";
 
     public function __construct($AppName)
     {
@@ -112,6 +114,19 @@ class AppConfig {
     {
         $val = $this->config->getAppValue($this->appName, $this->_autosave);
         if (empty($val)) $val = $this->predefAutosave;
+        return $val;
+    }
+
+    public function SetLibraries($libraries)
+    {
+        $this->logger->info("SetLibraries: " . $libraries, array("app" => $this->appName));
+        $this->config->setAppValue($this->appName, $this->_libraries, $libraries);
+    }
+
+    public function GetLibraries()
+    {
+        $val = $this->config->getAppValue($this->appName, $this->_libraries);
+        if (empty($val)) $val = $this->predefLibraries;
         return $val;
     }
 

--- a/drawio/templates/editor.php
+++ b/drawio/templates/editor.php
@@ -7,6 +7,10 @@
     {
         $frame_params .= "&offline=1&stealth=1";
     }
+    if ($_["drawioLibraries"] == "yes")
+    {
+        $frame_params .= "&libraries=1";
+    }
     if (!empty($_["drawioTheme"])) $frame_params .= "&ui=".$_["drawioTheme"];
     if (!empty($_["drawioLang"])) $frame_params .= "&lang=".$_["drawioLang"];
     if (!empty($_["drawioUrlArgs"])) $frame_params .= "&".$_["drawioUrlArgs"];

--- a/drawio/templates/settings.php
+++ b/drawio/templates/settings.php
@@ -47,6 +47,14 @@
             </select>
     </p>
 
+    <p class="drawio-header">
+        <label for='drawioLibraries'><?php p($l->t("Enable libraries?")) ?>
+            <select id="drawioLibraries">
+                <option value="yes"<?php if ($_["drawioLibraries"] === "yes") echo ' selected'; ?>><?php p($l->t("Yes")) ?></option>
+                <option value="no"<?php if ($_["drawioLibraries"] === "no") echo ' selected'; ?>><?php p($l->t("No")) ?></option>
+            </select>
+    </p>
+
     <br />
     <a id="drawioSave" class="button"><?php p($l->t("Save")) ?></a>
 </div>

--- a/drawio/templates/viewer.php
+++ b/drawio/templates/viewer.php
@@ -19,6 +19,10 @@
     {
         $frame_params .= "&offline=1&stealth=1";
     }
+    if ($_["drawioLibraries"] == "yes")
+    {
+        $frame_params .= "&libraries=1";
+    }
     if (!empty($_["drawioTheme"])) $frame_params .= "&ui=".$_["drawioTheme"];
     if (!empty($_["drawioLang"])) $frame_params .= "&lang=".$_["drawioLang"];
     if (!empty($_["drawioUrlArgs"])) $frame_params .= "&".$_["drawioUrlArgs"];


### PR DESCRIPTION
As mentioned [here](https://www.diagrams.net/doc/faq/embed-mode) there is an `libraries` option which enables the loading and managing of extra libraries. For this I've added the option to enable this because it defaults to `0` (disabled). This fixes issue #78 and partially #35.  