### PR TITLE
missing commas in #158 / #78

### DIFF
--- a/drawio/controller/settingscontroller.php
+++ b/drawio/controller/settingscontroller.php
@@ -64,7 +64,7 @@ class SettingsController extends Controller
             "drawioOfflineMode" => $this->config->GetOfflineMode(),
             "drawioTheme" => $this->config->GetTheme(),
             "drawioLang" => $this->config->GetLang(),
-            "drawioAutosave" => $this->config->GetAutosave()
+            "drawioAutosave" => $this->config->GetAutosave(),
             "drawioLibraries" => $this->config->GetLibraries()
         ];
         return new TemplateResponse($this->appName, "settings", $data, "blank");
@@ -105,7 +105,7 @@ class SettingsController extends Controller
             "offlineMode" => $this->config->GetOfflineMode(),
             "theme" => $this->config->GetTheme(),
             "lang" => $this->config->GetLang(),
-            "drawioAutosave" =>$this->config->GetAutosave()
+            "drawioAutosave" =>$this->config->GetAutosave(),
             "drawioLibraries" =>$this->config->GetLibraries()
             ];
     }


### PR DESCRIPTION
2 missing commas produced the following hard app error:

```
"reqId":"TBCx7s4S3xg5Op6ue0yF","level":3,"time":"2021-10-17T07:16:41+00:00","remoteAddr":"10.10.64.39","user":"--","app":"index","method":"GET","url":"/nextcloud/index.php/apps/drawio/ajax/settings","message":{"Exception":"ParseError","Message":"syntax error, unexpected '\"drawioLibraries\"' (T_CONSTANT_ENCAPSED_STRING), expecting ']'","Code":0,"Trace":[{"function":"load","class":"OC\\Autoloader","type":"->","args":["OCA\\Drawio\\Controller\\SettingsController"]},{"file":"/var/www/nextcloud/apps/drawio/appinfo/application.php","line":84,"function":"spl_autoload_call","args":["OCA\\Drawio\\Controller\\SettingsController"]},{"file":"/var/www/nextcloud/lib/private/AppFramework/Utility/SimpleContainer.php","line":155,"function":"OCA\\Drawio\\AppInfo\\{closure}","class":"OCA\\Drawio\\AppInfo\\Application","type":"->","args":["*** sensitive parameters replaced ***"]},{"file":"/var/www/nextcloud/3rdparty/pimple/pimple/src/Pimple/Container.php","line":118,"function":"OC\\AppFramework\\Utility\\{closure}","class":"OC\\AppFramework\\Utility\\SimpleContainer","type":"->","args":["*** sensitive parameters replaced ***"]},{"file":"/var/www/nextcloud/lib/private/AppFramework/Utility/SimpleContainer.php","line":122,"function":"offsetGet","class":"Pimple\\Container","type":"->","args":["SettingsController"]},{"file":"/var/www/nextcloud/lib/private/AppFramework/DependencyInjection/DIContainer.php","line":453,"function":"query","class":"OC\\AppFramework\\Utility\\SimpleContainer","type":"->","args":["SettingsController"]},{"file":"/var/www/nextcloud/lib/private/AppFramework/DependencyInjection/DIContainer.php","line":431,"function":"queryNoFallback","class":"OC\\AppFramework\\DependencyInjection\\DIContainer","type":"->","args":["SettingsController"]},{"file":"/var/www/nextcloud/lib/private/AppFramework/App.php","line":130,"function":"query","class":"OC\\AppFramework\\DependencyInjection\\DIContainer","type":"->","args":["SettingsController"]},{"file":"/var/www/nextcloud/lib/private/Route/Router.php","line":302,"function":"main","class":"OC\\AppFramework\\App","type":"::","args":["SettingsController","getsettings","*** sensitive parameter replaced ***",{"_route":"drawio.settings.getsettings"}]},{"file":"/var/www/nextcloud/lib/base.php","line":993,"function":"match","class":"OC\\Route\\Router","type":"->","args":["/apps/drawio/ajax/settings"]},{"file":"/var/www/nextcloud/index.php","line":37,"function":"handleRequest","class":"OC","type":"::","args":[]}],"File":"/var/www/nextcloud/apps/drawio/controller/settingscontroller.php","Line":68,"CustomMessage":"--"},"userAgent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36 Edg/94.0.992.50","version":"21.0.3.1"}
```