### PR TITLE
Check eTag in Edit Mode

### DIFF
--- a/drawio/controller/settingscontroller.php
+++ b/drawio/controller/settingscontroller.php
@@ -64,7 +64,7 @@ class SettingsController extends Controller
             "drawioOfflineMode" => $this->config->GetOfflineMode(),
             "drawioTheme" => $this->config->GetTheme(),
             "drawioLang" => $this->config->GetLang(),
-            "drawioAutosave" => $this->config->GetAutosave()
+            "drawioAutosave" => $this->config->GetAutosave(),
             "drawioLibraries" => $this->config->GetLibraries()
         ];
         return new TemplateResponse($this->appName, "settings", $data, "blank");
@@ -105,7 +105,7 @@ class SettingsController extends Controller
             "offlineMode" => $this->config->GetOfflineMode(),
             "theme" => $this->config->GetTheme(),
             "lang" => $this->config->GetLang(),
-            "drawioAutosave" =>$this->config->GetAutosave()
+            "drawioAutosave" =>$this->config->GetAutosave(),
             "drawioLibraries" =>$this->config->GetLibraries()
             ];
     }

--- a/drawio/controller/viewercontroller.php
+++ b/drawio/controller/viewercontroller.php
@@ -201,6 +201,11 @@ class ViewerController extends Controller
 
             if ($share_type === \OCP\Share::SHARE_TYPE_LINK) { // public links / anonymous editing should not be possible (?)
                 $params ['drawioReadOnly'] = true;
+
+                if (($share->getPermissions()) == 19) { // 19 = 16=PublicShare + 2=Update + 1=Read
+                    $params ['drawioReadOnly'] = false;
+                }          
+
             }
 
         }

--- a/drawio/controller/viewercontroller.php
+++ b/drawio/controller/viewercontroller.php
@@ -195,14 +195,16 @@ class ViewerController extends Controller
 
             $share_type = $share->getShareType();
 
-            if (($share->getPermissions() & Constants::PERMISSION_UPDATE) !== 0) {
+            $permissions = $share->getPermissions();
+            if (($permissions & Constants::PERMISSION_UPDATE) !== 0) {
                 $params ['drawioReadOnly'] = false;
             }
 
             if ($share_type === \OCP\Share::SHARE_TYPE_LINK) { // public links / anonymous editing should not be possible (?)
                 $params ['drawioReadOnly'] = true;
-
-                if (($share->getPermissions()) == 19) { // 19 = 16=PublicShare + 2=Update + 1=Read
+                
+                if ($permissions == CONSTANTS::PERMISSION_READ + CONSTANTS::PERMISSION_UPDATE   // 3 = 1 + 2
+                    or $permissions == CONSTANTS::PERMISSION_SHARE + CONSTANTS::PERMISSION_READ + CONSTANTS::PERMISSION_UPDATE) { // 19 = 16 + 1 + 2
                     $params ['drawioReadOnly'] = false;
                 }          
 

--- a/drawio/js/editor.js
+++ b/drawio/js/editor.js
@@ -198,7 +198,6 @@
                         var saveMsg = OC.Notification.show(t(OCA.DrawIO.AppName, "Saving...")); 
 
                         saveInProgress = true;
-                        var time = new Date();
                         $.ajax({
                             url: webdavUrl,
                             type: 'PUT',
@@ -227,7 +226,8 @@
                                         }	
 
                                         // Chose "Confirm":  
-                                        saveInProgress = true;                                      
+                                        saveInProgress = true;
+                                        var time = new Date();                         
                                         $.ajax({
                                             url: webdavUrl,
                                             type: 'PUT',

--- a/drawio/js/editor.js
+++ b/drawio/js/editor.js
@@ -175,7 +175,7 @@
                         .fail(function (result) {
                             saveInProgress = false; 
 
-                            if (result.status == '412' && result.statusText == "Precondition Failed") { // Wrong ETag              
+                            if (result.status == 412) { // Wrong ETag -> 412="Precondition Failed"
                                 OC.Notification.showTemporary(t(OCA.DrawIO.AppName, "Error while saving, please try saving manually."));	
                                 editWindow.postMessage(JSON.stringify({
                                     action: 'status',
@@ -189,6 +189,9 @@
                                     modified: false
                                 }), '*');
                             }
+                        })
+                        .done(function () {
+                            OC.Notification.hide(saveMsg);
                         });
 
                     }
@@ -213,7 +216,7 @@
                         })
                         .fail(function (result) {
                             // TODO: handle on failed write
-                            if (result.status == '412' && result.statusText == "Precondition Failed") { // Wrong ETag
+                            if (result.status == 412) { // Wrong ETag -> 412="Precondition Failed"
                                 OC.dialogs.confirmHtml(
                                     'File was already changed by another User. Overwrite?',
                                     'Save Failed !',

--- a/drawio/js/editor.js
+++ b/drawio/js/editor.js
@@ -230,9 +230,9 @@
                                         draftShown = true; // Draft Modal was opened
                                         editWindow.postMessage(JSON.stringify({
                                             action: 'draft',
-                                            name: 'Remote File',                                            
-                                            editKey: 'Load',
-                                            discardKey: 'Overwrite',                                                                                                                    
+                                            name: 'REMOTE FILE',                                            
+                                            editKey: 'import',
+                                            discardKey: 'replace',                                                                                                                  
                                             xml: contents
                                         }), '*');
                                     

--- a/drawio/js/settings.js
+++ b/drawio/js/settings.js
@@ -54,7 +54,7 @@
                         $("#theme").val(response.theme);
                         $("#lang").val(response.lang);
                         $("#drawioAutosave").val(response.drawioAutosave);
-                        $("#drawioLibraries").val(response.libraries);
+                        $("#drawioLibraries").val(response.drawioLibraries);
 
                         var message =
                             response.error

--- a/drawio/templates/settings.php
+++ b/drawio/templates/settings.php
@@ -15,6 +15,7 @@
       <option value="min"<?php if ($_["drawioTheme"] === "min") echo ' selected'; ?>><?php p($l->t("Minimal")) ?></option>
       <option value="atlas"<?php if ($_["drawioTheme"] === "atlas") echo ' selected'; ?>><?php p($l->t("Atlas")) ?></option>
       <option value="dark"<?php if ($_["drawioTheme"] === "dark") echo ' selected'; ?>><?php p($l->t("Dark")) ?></option>
+      <option value="sketch"<?php if ($_["drawioTheme"] === "sketch") echo ' selected'; ?>><?php p($l->t("Sketch")) ?></option>
     </select>
     </p>
 


### PR DESCRIPTION
A Proposal to address the fact that 2+ People concurrently working on the same document, are prone to overwriting each others work. (see #163 #14 #74 #120)
Now this is an attempt to check the eTag Header of the Diagram, and let the User decide on how to proceed in case of a conflict.

On Conflict between local file state <> remote file state:
- When Autosave is enabled: Error Message warns the user and asks him to "Save" manually.
- "Save" Button: Draft Modal opens, that.. 
  -  ..shows the remote Versions Diagram
  -  ..asks the User how to proceed:
      - Import the Remote File into the local Users Editor
      - Replace the Remote File

Needs extensive testing, help appreciated!

![GIF](https://user-images.githubusercontent.com/5107805/137884042-e6ddb6d7-3a67-4f6e-aa7d-aaac9bd64345.gif)


